### PR TITLE
Improve waterlily on_place

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -323,7 +323,7 @@ function flowers.flower_spread(pos, node)
 	pos.y = pos.y - 1
 	local under = minetest.get_node(pos)
 	pos.y = pos.y + 1
-  
+
   -- Replace flora with dry shrub in desert sand and silver sand,
 	-- as this is the only way to generate them.
 	-- However, preserve grasses in sand dune biomes.
@@ -647,7 +647,6 @@ if not flowers.reg3 then
 			local node = minetest.get_node(pointed_thing.under)
 			local name = node.name
 			local def = minetest.reg_ns_nodes[name]
-			local player_name = placer:get_player_name()
 
 			-- Pass through interactions to nodes that define them (like chests).
 			if def.on_rightclick and not placer:get_player_control().sneak then
@@ -659,6 +658,8 @@ if not flowers.reg3 then
 
 			if def and def.liquidtype == "source" and
 					minetest.get_item_group(name, "water") > 0 then
+
+				local player_name = placer:get_player_name()
 				if not minetest.is_protected(pos, player_name) then
 					minetest.add_node(pos, {name = "flowers:waterlily",
 					param2 = math_random(0, 3)})

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -660,13 +660,13 @@ if not flowers.reg3 then
 					minetest.get_item_group(name, "water") > 0 then
 
 				local player_name = placer:get_player_name()
-				if not minetest.is_protected(pos, player_name) then
+				if minetest.is_protected(pos, player_name) then
+					minetest.chat_send_player(player_name, "# Server: Position is protected.")
+					minetest.record_protection_violation(pos, player_name)
+				else
 					minetest.add_node(pos, {name = "flowers:waterlily",
 						param2 = math_random(0, 3)})
 					itemstack:take_item()
-				else
-					minetest.chat_send_player(player_name, "# Server: Position is protected.")
-					minetest.record_protection_violation(pos, player_name)
 				end
 			end
 

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -649,7 +649,7 @@ if not flowers.reg3 then
 			local def = minetest.reg_ns_nodes[name]
 
 			-- Pass through interactions to nodes that define them (like chests).
-			if def.on_rightclick and placer and not placer:get_player_control().sneak then
+			if def and def.on_rightclick and placer and not placer:get_player_control().sneak then
 				return def.on_rightclick(pointed_thing.under, node, placer, itemstack, pointed_thing)
 			end
 

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -662,7 +662,7 @@ if not flowers.reg3 then
 				local player_name = placer:get_player_name()
 				if not minetest.is_protected(pos, player_name) then
 					minetest.add_node(pos, {name = "flowers:waterlily",
-					param2 = math_random(0, 3)})
+						param2 = math_random(0, 3)})
 					itemstack:take_item()
 				else
 					minetest.chat_send_player(player_name, "# Server: Position is protected.")

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -656,7 +656,7 @@ if not flowers.reg3 then
 			-- Lilies are placeable in any water.
 			-- They only grow further in regular water sources.
 
-			if def and def.liquidtype == "source" and
+			if def and def.liquidtype == "source" and placer and
 					minetest.get_item_group(name, "water") > 0 then
 
 				local player_name = placer:get_player_name()

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -644,15 +644,21 @@ if not flowers.reg3 then
 
 		on_place = function(itemstack, placer, pointed_thing)
 			local pos = pointed_thing.above
-			local node = minetest.get_node(pointed_thing.under).name
-			local def = minetest.reg_ns_nodes[node]
+			local node = minetest.get_node(pointed_thing.under)
+			local name = node.name
+			local def = minetest.reg_ns_nodes[name]
 			local player_name = placer:get_player_name()
+
+			-- Pass through interactions to nodes that define them (like chests).
+			if def.on_rightclick and not placer:get_player_control().sneak then
+				return def.on_rightclick(pointed_thing.under, node, placer, itemstack, pointed_thing)
+			end
 
 			-- Lilies are placeable in any water.
 			-- They only grow further in regular water sources.
 
 			if def and def.liquidtype == "source" and
-					minetest.get_item_group(node, "water") > 0 then
+					minetest.get_item_group(name, "water") > 0 then
 				if not minetest.is_protected(pos, player_name) then
 					minetest.add_node(pos, {name = "flowers:waterlily",
 					param2 = math_random(0, 3)})

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -649,7 +649,7 @@ if not flowers.reg3 then
 			local def = minetest.reg_ns_nodes[name]
 
 			-- Pass through interactions to nodes that define them (like chests).
-			if def.on_rightclick and not placer:get_player_control().sneak then
+			if def.on_rightclick and placer and not placer:get_player_control().sneak then
 				return def.on_rightclick(pointed_thing.under, node, placer, itemstack, pointed_thing)
 			end
 


### PR DESCRIPTION
This fixes waterlilies not being placeable on itemframes/pedestals, and a bunch of operatable nodes (doors, chests, levers, etc.) not working while being right-clicked holding waterlilies.

Edit: I was hoping @waxtatect would adopt this while integrating their suggested changes, but since some time has passed I'm reopening it. So as of 2024/05/23: re-opened, rebased, added suggestions by @waxtatect (hope I got them correctly? github is confusing... Please check what I did!)

Edit 2: I beseech you, if you ever do it, be it a squash merge! For goodness sake...!