### PR TITLE
Welcome message should be the first

### DIFF
--- a/mods/player_labels/init.lua
+++ b/mods/player_labels/init.lua
@@ -139,7 +139,10 @@ player_labels.on_joinplayer = function(player)
   if player_labels.cast[pname] then
     nametag_show(pname)
   else
-    minetest.chat_send_player(pname, "# Server: Avatar name broadcast is OFF.")
+    -- After welcome msg, before joinspec and email.
+    minetest.after(5, function(pn)
+      minetest.chat_send_player(pn, "# Server: Avatar name broadcast is OFF.")
+    end, pname)
     nametag_hide(pname)
   end
 end


### PR DESCRIPTION
I forgot this while implementing the feature (ref. [previous PR on notabug](https://notabug.org/BlueBird51/musttest_game/pulls/121)).

Five seconds chosen so to make it show before the email (10s) and the Outback dry winds/Midfeld fog of time (30s) ones.

![chat](https://github.com/BluebirdGreycoat/musttest_game/assets/63740606/1634ec2d-6f3b-4bed-b6c8-aa9489c093a6)
