### PR TITLE
QoL: chest formspecs

### DIFF
--- a/mods/chest_api/functions.lua
+++ b/mods/chest_api/functions.lua
@@ -346,7 +346,9 @@ chest_api.get_share_formspec = function(pos, meta)
     "button[2.5,3.14;2,1.02;delname;Remove Name]" ..
     "label[0,1.71;Add or remove access grants:]" ..
     "field[0.27,2.46;2.5,1;addname_field;;]" ..
+    "field_close_on_enter[addname_field;false]" ..
     "field[0.27,3.46;2.5,1;delname_field;;]" ..
+    "field_close_on_enter[delname_field;false]" ..
     "label[0,4;Tip: any locked chest can be shared with a key.]"
   
   formspec = formspec ..
@@ -670,7 +672,7 @@ function chest_api.on_player_receive_fields(player, formname, fields)
     end
   end
 
-  if fields.addname and fields.addname_field ~= "" then -- Sharing formspec only.
+  if (fields.addname or fields.key_enter_field == "addname_field") and fields.addname_field ~= "" then -- Sharing formspec only.
 		-- Permit grandfathering of old shared ironside chests.
 		local shares, sharecount = get_share_names(meta)
 
@@ -688,7 +690,7 @@ function chest_api.on_player_receive_fields(player, formname, fields)
     end
   end
 
-  if fields.delname then -- Sharing formspec only.
+  if fields.delname or fields.key_enter_field == "delname_field" then -- Sharing formspec only.
 		-- Permit grandfathering of old shared ironside chests.
 		local shares, sharecount = get_share_names(meta)
 

--- a/mods/chest_api/functions.lua
+++ b/mods/chest_api/functions.lua
@@ -147,11 +147,11 @@ chest_api.get_chest_formspec = function(name, desc, pos)
     
     -- Locked gold chest.
     if string.find(name, "locked") then 
-      local chest_name = meta:get_string("chest_name") or ""
+      local chest_name = F(meta:get_string("chest_name") or "")
       formspec = formspec .. "button[10,0;2,1;rename;Rename]" ..
-        "field[8.25,0.45;2,0.75;name;;]" ..
+        "field[8.25,0.45;2,0.75;name;;" .. chest_name .. "]" ..
         "field_close_on_enter[name;false]" ..
-        "label[0,0.35;Label: <" .. F(chest_name) .. ">]"
+        "label[0,0.35;Label: <" .. chest_name .. ">]"
     end
 
 	-- Locked or unlocked diamond chest.
@@ -171,11 +171,11 @@ chest_api.get_chest_formspec = function(name, desc, pos)
 
     -- Locked diamond chest.
     if string.find(name, "locked") then
-      local chest_name = meta:get_string("chest_name") or ""
+      local chest_name = F(meta:get_string("chest_name") or "")
       formspec = formspec .. "button[10,0;2,1;rename;Rename]" ..
-        "field[8.25,0.45;2,0.75;name;;]" ..
+        "field[8.25,0.45;2,0.75;name;;" .. chest_name .. "]" ..
         "field_close_on_enter[name;false]" ..
-        "label[0,0.35;Label: <" .. F(chest_name) .. ">]"
+        "label[0,0.35;Label: <" .. chest_name .. ">]"
     end
 
 	-- Locked or unlocked mithril chest.
@@ -195,16 +195,16 @@ chest_api.get_chest_formspec = function(name, desc, pos)
 
     -- Locked mithril chest.
     if string.find(name, "locked") then
-      local chest_name = meta:get_string("chest_name") or ""
+      local chest_name = F(meta:get_string("chest_name") or "")
       formspec = formspec .. "button[12,0;2,1;rename;Rename]" ..
-        "field[10.25,0.45;2,0.75;name;;]" ..
+        "field[10.25,0.45;2,0.75;name;;" .. chest_name .. "]" ..
         "field_close_on_enter[name;false]" ..
-        "label[0,0.35;Label: <" .. F(chest_name) .. ">]"
+        "label[0,0.35;Label: <" .. chest_name .. ">]"
     end
     
   -- Locked silver chest. (This chest is shareable.) Grandfather in old ironside chests.
   elseif (string.find(name, "silver") and string.find(name, "locked")) or sharecount > 0 then
-    local chest_name = meta:get_string("chest_name") or ""
+    local chest_name = F(meta:get_string("chest_name") or "")
     formspec = "size[10,10]" .. defgui ..
       "list[nodemeta:" .. spos .. ";main;0,1.3;8,4;]" ..
       "list[current_player;main;0,5.85;8,1;]" ..
@@ -214,9 +214,9 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       "label[0,0;" .. desc .. "]" ..
       default.get_hotbar_bg(0, 5.85) ..
       "button[6,0;2,1;rename;Rename]" ..
-      "field[4.25,0.45;2,0.75;name;;]" ..
+      "field[4.25,0.45;2,0.75;name;;" .. chest_name .. "]" ..
       "field_close_on_enter[name;false]" ..
-      "label[0,0.35;Label: <" .. F(chest_name) .. ">]" ..
+      "label[0,0.35;Label: <" .. chest_name .. ">]" ..
       "button[8,1.2;2,1;doshare;Share Chest]" ..
       "button[8,2.2;2,1;unshare;Unshare]" ..
       "tooltip[unshare;Warning:\n\nThis will remove all the players\nfrom the access list of this chest!]"
@@ -252,11 +252,11 @@ chest_api.get_chest_formspec = function(name, desc, pos)
     -- (If chest was locked silver, then another if-statement already handled it.)
 		-- Iron locked chests with existing shares are grandfathered in.
     if locked then
-      local chest_name = meta:get_string("chest_name") or ""
+      local chest_name = F(meta:get_string("chest_name") or "")
       formspec = formspec .. "button[6,0;2,1;rename;Rename]" ..
-        "field[4.25,0.45;2,0.75;name;;]" ..
+        "field[4.25,0.45;2,0.75;name;;" .. chest_name .. "]" ..
         "field_close_on_enter[name;false]" ..
-        "label[0,0.35;Label: <" .. F(chest_name) .. ">]"
+        "label[0,0.35;Label: <" .. chest_name .. ">]"
 
 				-- Trash icon.
 				.. "list[" .. ltrash .. ";" .. mtrash .. ";8,1.3;1,1;]" ..

--- a/mods/chest_api/functions.lua
+++ b/mods/chest_api/functions.lua
@@ -303,6 +303,12 @@ end
 local function add_share_name(meta, name, pname)
   if name == "" then return end -- Failsafe.
 	name = rename.grn(name)
+  -- Being able to get rid of ghosts from the past may be a good idea.
+  -- Being able to shove them in the future probably isn't.
+  if not minetest.player_exists(name) then
+    minetest.chat_send_player(pname, "# Server: Can't add non-existent player <" .. rename.gpn(name) .. ">.")
+    return
+  end
   local share_names, share_count = get_share_names(meta)
   if not share_names[name] then
     minetest.chat_send_player(pname, "# Server: Player <" .. rename.gpn(name) .. "> will now have access to " .. get_chest_name(meta) .. ".")

--- a/mods/chest_api/functions.lua
+++ b/mods/chest_api/functions.lua
@@ -1,8 +1,8 @@
 
--- Localize vector.distance() for performance.
+-- Localize for performance.
+local F = minetest.formspec_escape
 local vector_distance = vector.distance
 local math_random = math.random
-
 
 
 -- This function is responsible for triggering the update of vending
@@ -151,7 +151,7 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       formspec = formspec .. "button[10,0;2,1;rename;Rename]" ..
         "field[8.25,0.45;2,0.75;name;;]" ..
         "field_close_on_enter[name;false]" ..
-        "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]"
+        "label[0,0.35;Label: <" .. F(chest_name) .. ">]"
     end
 
 	-- Locked or unlocked diamond chest.
@@ -175,7 +175,7 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       formspec = formspec .. "button[10,0;2,1;rename;Rename]" ..
         "field[8.25,0.45;2,0.75;name;;]" ..
         "field_close_on_enter[name;false]" ..
-        "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]"
+        "label[0,0.35;Label: <" .. F(chest_name) .. ">]"
     end
 
 	-- Locked or unlocked mithril chest.
@@ -199,7 +199,7 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       formspec = formspec .. "button[12,0;2,1;rename;Rename]" ..
         "field[10.25,0.45;2,0.75;name;;]" ..
         "field_close_on_enter[name;false]" ..
-        "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]"
+        "label[0,0.35;Label: <" .. F(chest_name) .. ">]"
     end
     
   -- Locked silver chest. (This chest is shareable.) Grandfather in old ironside chests.
@@ -216,7 +216,7 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       "button[6,0;2,1;rename;Rename]" ..
       "field[4.25,0.45;2,0.75;name;;]" ..
       "field_close_on_enter[name;false]" ..
-      "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]" ..
+      "label[0,0.35;Label: <" .. F(chest_name) .. ">]" ..
       "button[8,1.2;2,1;doshare;Share Chest]" ..
       "button[8,2.2;2,1;unshare;Unshare]" ..
       "tooltip[unshare;Warning:\n\nThis will remove all the players\nfrom the access list of this chest!]"
@@ -256,7 +256,7 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       formspec = formspec .. "button[6,0;2,1;rename;Rename]" ..
         "field[4.25,0.45;2,0.75;name;;]" ..
         "field_close_on_enter[name;false]" ..
-        "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]"
+        "label[0,0.35;Label: <" .. F(chest_name) .. ">]"
 
 				-- Trash icon.
 				.. "list[" .. ltrash .. ";" .. mtrash .. ";8,1.3;1,1;]" ..
@@ -350,8 +350,8 @@ chest_api.get_share_formspec = function(pos, meta)
     default.gui_slots
   
   formspec = "size[8,5]" .. defgui ..
-    "label[0,0;" .. minetest.formspec_escape(utility.get_short_desc(desc)) .. "]" ..
-    "label[0,0.35;Label: <" .. minetest.formspec_escape(cname) .. ">]" ..
+    "label[0,0;" .. F(utility.get_short_desc(desc)) .. "]" ..
+    "label[0,0.35;Label: <" .. F(cname) .. ">]" ..
     "button[6,0;2,1;unshare;Unshare]" ..
     "tooltip[unshare;Warning:\n\nThis will remove all the players\nfrom the access list of this chest!]" ..
     "button_exit[6,4;2,1;quit;Close]" ..
@@ -369,7 +369,7 @@ chest_api.get_share_formspec = function(pos, meta)
   
   local share_names, share_count = get_share_names(meta)
   for k, v in pairs(share_names) do
-    formspec = formspec .. minetest.formspec_escape(rename.gpn(k)) .. ","
+    formspec = formspec .. F(rename.gpn(k)) .. ","
   end 
   formspec = string.gsub(formspec, ",$", "") -- Remove trailing comma.
   formspec = formspec .. "]"

--- a/mods/chest_api/functions.lua
+++ b/mods/chest_api/functions.lua
@@ -312,6 +312,7 @@ local function add_share_name(meta, name, pname)
   -- Being able to shove them in the future probably isn't.
   if not minetest.player_exists(name) then
     minetest.chat_send_player(pname, "# Server: Can't add non-existent player <" .. rename.gpn(name) .. ">.")
+    easyvend.sound_error(pname)
     return
   end
   local share_names, share_count = get_share_names(meta)
@@ -331,6 +332,7 @@ local function del_share_name(meta, name, pname)
     minetest.chat_send_player(pname, "# Server: Player <" .. rename.gpn(name) .. "> can no longer access " .. get_chest_name(meta) .. ".")
   else
     minetest.chat_send_player(pname, "# Server: Player <" .. rename.gpn(name) .. "> was not in the access list of " .. get_chest_name(meta) .. ".")
+    easyvend.sound_error(pname)
   end
   share_names[name] = nil
   local str = minetest.write_json(share_names) -- Returns nil for empty table?
@@ -642,9 +644,11 @@ function chest_api.on_player_receive_fields(player, formname, fields)
         minetest.show_formspec(pn, "default:chest", chest_api.get_chest_formspec(nn, desc, pos))
       else
         minetest.chat_send_player(pn, "# Server: You cannot relabel this chest.")
+        easyvend.sound_error(pn)
       end
     else
       minetest.chat_send_player(pn, "# Server: This chest does not have labeling functionality.")
+      easyvend.sound_error(pn)
     end
   end
 
@@ -657,9 +661,11 @@ function chest_api.on_player_receive_fields(player, formname, fields)
         minetest.show_formspec(pn, "default:chest_share", chest_api.get_share_formspec(pos, meta))
       else
         minetest.chat_send_player(pn, "# Server: You do not have permission to manage shares for this chest.")
+        easyvend.sound_error(pn)
       end
     else
       minetest.chat_send_player(pn, "# Server: This chest does not have sharing functionality.")
+      easyvend.sound_error(pn)
     end
   end
 
@@ -679,9 +685,11 @@ function chest_api.on_player_receive_fields(player, formname, fields)
         end
       else
         minetest.chat_send_player(pn, "# Server: You do not have permission to manage shares for this chest.")
+        easyvend.sound_error(pn)
       end
     else
       minetest.chat_send_player(pn, "# Server: This chest does not have sharing functionality.")
+      easyvend.sound_error(pn)
     end
   end
 
@@ -698,12 +706,15 @@ function chest_api.on_player_receive_fields(player, formname, fields)
           minetest.show_formspec(pn, "default:chest_share", chest_api.get_share_formspec(pos, meta))
         else
           minetest.chat_send_player(pn, "# Server: You must specify a player name to add to the access the list.")
+          easyvend.sound_error(pn)
         end
       else
         minetest.chat_send_player(pn, "# Server: You do not have permission to manage shares for this chest.")
+        easyvend.sound_error(pn)
       end
     else
       minetest.chat_send_player(pn, "# Server: This chest does not have sharing functionality.")
+      easyvend.sound_error(pn)
     end
   end
 
@@ -720,12 +731,15 @@ function chest_api.on_player_receive_fields(player, formname, fields)
           minetest.show_formspec(pn, "default:chest_share", chest_api.get_share_formspec(pos, meta))
         else
           minetest.chat_send_player(pn, "# Server: You must specify a player name to remove from the access the list.")
+          easyvend.sound_error(pn)
         end
       else
         minetest.chat_send_player(pn, "# Server: You do not have permission to manage shares for this chest.")
+        easyvend.sound_error(pn)
       end
     else
       minetest.chat_send_player(pn, "# Server: This chest does not have sharing functionality.")
+      easyvend.sound_error(pn)
     end
   end
 
@@ -765,9 +779,11 @@ function chest_api.on_player_receive_fields(player, formname, fields)
         end
       else
         minetest.chat_send_player(pn, "# Server: You do not have permission to manage shares for this chest.")
+        easyvend.sound_error(pn)
       end
     else
       minetest.chat_send_player(pn, "# Server: This chest does not have sharing functionality.")
+      easyvend.sound_error(pn)
     end
   end
 

--- a/mods/chest_api/functions.lua
+++ b/mods/chest_api/functions.lua
@@ -214,7 +214,8 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       "field[4.25,0.45;2,0.75;name;;]" ..
       "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]" ..
       "button[8,1.2;2,1;doshare;Share Chest]" ..
-      "button[8,2.2;2,1;unshare;Unshare]"
+      "button[8,2.2;2,1;unshare;Unshare]" ..
+      "tooltip[unshare;Warning:\n\nThis will remove all the players\nfrom the access list of this chest!]"
 
 			-- Trash icon.
 			.. "list[" .. ltrash .. ";" .. mtrash .. ";9,5.85;1,1;]" ..
@@ -339,6 +340,7 @@ chest_api.get_share_formspec = function(pos, meta)
     "label[0,0;" .. minetest.formspec_escape(utility.get_short_desc(desc)) .. "]" ..
     "label[0,0.35;Label: <" .. minetest.formspec_escape(cname) .. ">]" ..
     "button[6,0;2,1;unshare;Unshare]" ..
+    "tooltip[unshare;Warning:\n\nThis will remove all the players\nfrom the access list of this chest!]" ..
     "button_exit[6,4;2,1;quit;Close]" ..
     "button[2.5,2.14;2,1.02;addname;Add Name]" ..
     "button[2.5,3.14;2,1.02;delname;Remove Name]" ..

--- a/mods/chest_api/functions.lua
+++ b/mods/chest_api/functions.lua
@@ -672,16 +672,20 @@ function chest_api.on_player_receive_fields(player, formname, fields)
     end
   end
 
-  if (fields.addname or fields.key_enter_field == "addname_field") and fields.addname_field ~= "" then -- Sharing formspec only.
+  if fields.addname or fields.key_enter_field == "addname_field" then -- Sharing formspec only.
 		-- Permit grandfathering of old shared ironside chests.
 		local shares, sharecount = get_share_names(meta)
 
     if (string.find(nn, "silver") and string.find(nn, "locked")) or sharecount > 0 then
       if owner == pn or gdac.player_is_admin(pn) then
-        add_share_name(meta, fields.addname_field, pn)
+        if fields.addname_field ~= "" then
+          add_share_name(meta, fields.addname_field, pn)
 
-        -- The sharing formspec is being displayed. Refresh it.
-        minetest.show_formspec(pn, "default:chest_share", chest_api.get_share_formspec(pos, meta))
+          -- The sharing formspec is being displayed. Refresh it.
+          minetest.show_formspec(pn, "default:chest_share", chest_api.get_share_formspec(pos, meta))
+        else
+          minetest.chat_send_player(pn, "# Server: You must specify a player name to add to the access the list.")
+        end
       else
         minetest.chat_send_player(pn, "# Server: You do not have permission to manage shares for this chest.")
       end
@@ -696,10 +700,14 @@ function chest_api.on_player_receive_fields(player, formname, fields)
 
     if (string.find(nn, "silver") and string.find(nn, "locked")) or sharecount > 0 then
       if owner == pn or gdac.player_is_admin(pn) then
-        del_share_name(meta, fields.delname_field, pn)
+        if fields.delname_field ~= "" then
+          del_share_name(meta, fields.delname_field, pn)
 
-        -- The sharing formspec is being displayed. Refresh it.
-        minetest.show_formspec(pn, "default:chest_share", chest_api.get_share_formspec(pos, meta))
+          -- The sharing formspec is being displayed. Refresh it.
+          minetest.show_formspec(pn, "default:chest_share", chest_api.get_share_formspec(pos, meta))
+        else
+          minetest.chat_send_player(pn, "# Server: You must specify a player name to remove from the access the list.")
+        end
       else
         minetest.chat_send_player(pn, "# Server: You do not have permission to manage shares for this chest.")
       end

--- a/mods/chest_api/functions.lua
+++ b/mods/chest_api/functions.lua
@@ -324,6 +324,8 @@ local function del_share_name(meta, name, pname)
   local share_names, share_count = get_share_names(meta)
   if share_names[name] then
     minetest.chat_send_player(pname, "# Server: Player <" .. rename.gpn(name) .. "> can no longer access " .. get_chest_name(meta) .. ".")
+  else
+    minetest.chat_send_player(pname, "# Server: Player <" .. rename.gpn(name) .. "> was not in the access list of " .. get_chest_name(meta) .. ".")
   end
   share_names[name] = nil
   local str = minetest.write_json(share_names) -- Returns nil for empty table?

--- a/mods/chest_api/functions.lua
+++ b/mods/chest_api/functions.lua
@@ -150,6 +150,7 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       local chest_name = meta:get_string("chest_name") or ""
       formspec = formspec .. "button[10,0;2,1;rename;Rename]" ..
         "field[8.25,0.45;2,0.75;name;;]" ..
+        "field_close_on_enter[name;false]" ..
         "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]"
     end
 
@@ -173,6 +174,7 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       local chest_name = meta:get_string("chest_name") or ""
       formspec = formspec .. "button[10,0;2,1;rename;Rename]" ..
         "field[8.25,0.45;2,0.75;name;;]" ..
+        "field_close_on_enter[name;false]" ..
         "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]"
     end
 
@@ -196,6 +198,7 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       local chest_name = meta:get_string("chest_name") or ""
       formspec = formspec .. "button[12,0;2,1;rename;Rename]" ..
         "field[10.25,0.45;2,0.75;name;;]" ..
+        "field_close_on_enter[name;false]" ..
         "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]"
     end
     
@@ -212,6 +215,7 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       default.get_hotbar_bg(0, 5.85) ..
       "button[6,0;2,1;rename;Rename]" ..
       "field[4.25,0.45;2,0.75;name;;]" ..
+      "field_close_on_enter[name;false]" ..
       "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]" ..
       "button[8,1.2;2,1;doshare;Share Chest]" ..
       "button[8,2.2;2,1;unshare;Unshare]" ..
@@ -251,6 +255,7 @@ chest_api.get_chest_formspec = function(name, desc, pos)
       local chest_name = meta:get_string("chest_name") or ""
       formspec = formspec .. "button[6,0;2,1;rename;Rename]" ..
         "field[4.25,0.45;2,0.75;name;;]" ..
+        "field_close_on_enter[name;false]" ..
         "label[0,0.35;Label: <" .. minetest.formspec_escape(chest_name) .. ">]"
 
 				-- Trash icon.
@@ -611,7 +616,7 @@ function chest_api.on_player_receive_fields(player, formname, fields)
     return true -- Abort.
   end
 
-  if fields.rename then
+  if fields.rename or fields.key_enter_field == "name" then
     -- Anitcheat check.
     if (string.find(nn, "copper") or string.find(nn, "diamond") or
         string.find(nn, "iron") or


### PR DESCRIPTION
Hello, this adds the following "features" to `chest_api`:

- Ability to rename a chest by hitting 'Enter' while focus is on the 'Label' field of the chest formspec.
- Ability to add a player to/remove them from the access list of a silver chest by hitting 'Enter' while the focus is on the respective field.
- A sanity check requiring that only existent players may be added to silver chests (not adding such requirement for removal, ofc.)
- A few feedback messages to the above commands, mainly to report failures.
- The easyvend error sound to the above commands when one of such failures occur. (*1)
- When double-clicking a name in the shared access list of a silver chest, the 'Remove Player' field is automatically filled with the selected name. (*2)
- Two tooltip elements on the silver chest 'Unshare' buttons, warning the player that by clicking them the whole access list will be erased.

The code should be ready for review.

I tried to isolate the features in separate commits such that, by the magics of git, they could somehow be cherry-picked as needed, may something be unwanted. Otherwise, a squash would be advisable!

Thanks for considering this.

---
Notes:

1) It may be a little harsh that when sending the easyvend error sound to the client, the standard formspec 'click' sound is also sent and the two overlap. I could not figure how to prevent the 'click' sound from being sent, if that's possible at all?

2) This commit contains some severe ugliness, but it's a take-it-or-leave-it. Doing it properly would require too much effort (a per-player context) which would not be worth for the little benefit it gives in the game, which is, saving a few keystrokes. Please double-check it. I tried to better explain in the code itself (see the comment).