### PR TITLE
QoL: Jaunt, teleports and safes

### DIFF
--- a/mods/chest_api/functions.lua
+++ b/mods/chest_api/functions.lua
@@ -357,7 +357,7 @@ chest_api.get_share_formspec = function(pos, meta, pname)
 		local selected_name = context.sharelist_index or 0
 		local sharelist_names = context.sharelist_names or {}
 		if selected_name >= 1 and selected_name <= #sharelist_names then
-			delname = sharelist_names[selected_name]
+			delname = rename.gpn(sharelist_names[selected_name])
 		end
 	end
 

--- a/mods/jaunt/init.lua
+++ b/mods/jaunt/init.lua
@@ -17,11 +17,11 @@ function jaunt.get_formspec(player)
 
 	formspec = formspec ..
 		"item_image[0,0;1,1;passport:passport_adv]" ..
-    "label[1,0;Key: Teleport to player beacon.]" ..
-    "label[1,0.4;Requires teleport for anchor.]" ..
+		"label[1,0;Key: Teleport to player beacon.]" ..
+		"label[1,0.4;Requires teleport for anchor.]" ..
 		"field[0.3,1.3;2.9,1;player;;]" ..
 		"button[3.0,1.0;1.5,1;go;Jaunt]" ..
-		"field_close_on_enter[player;true]" ..
+		"field_close_on_enter[player;false]" ..
 		"button[1.25,2.0;2.25,1;cancel;Abort]" ..
     "label[0,3;Jaunt range is influenced by the status\nof the target's beacon. Marked players can\nbe found from farther.]" ..
 		"item_image[1.25,4.5;1,1;command_tokens:mark_player]" ..
@@ -75,7 +75,7 @@ jaunt.on_receive_fields = function(player, formname, fields)
     passport.show_formspec(pname)
 		return true
 	end
-	if fields.quit then
+	if fields.quit and not fields.key_enter_field then
 		return true
 	end
 
@@ -178,7 +178,7 @@ jaunt.on_receive_fields = function(player, formname, fields)
 										end,
 									})
 
-									-- don't reshow the formspec
+									-- Close the formspec.
 									minetest.close_formspec(pname, "jaunt:fs")
 									return true
 								else

--- a/mods/safe/safe.lua
+++ b/mods/safe/safe.lua
@@ -328,10 +328,14 @@ function safe.get_formspec(pos, pname)
 
   if locked then
 		-- Locked formspec.
+		local ndef = minetest.registered_nodes[minetest.get_node(pos).name]
+		local cn = ndef._safe_common_name
+
 		if pname == owner then
 			formspec = "size[3.4,5.1]" .. defgui .. "real_coordinates[true]" ..
 				"label[1.1,1.1;Enter Password]" ..
 				"pwdfield[1.1,1.4;2.5,0.5;pin_entry;]" ..
+				"button_exit[1.1,2.0;2.5,0.5t;unlock_safe;Unlock " .. cn .. "]" ..
 				"label[1.1,3.1;Change Password]" ..
 				"label[0.4,3.65;Old]" ..
 				"label[0.4,4.25;New]" ..
@@ -339,11 +343,12 @@ function safe.get_formspec(pos, pname)
 				"pwdfield[1.1,3.4;2.5,0.5;old_password;]" ..
 				"pwdfield[1.1,4.0;2.5,0.5;new_password;]" ..
 				"pwdfield[1.1,4.6;2.5,0.5;confirm_password;]" ..
-				"button_exit[1.1,5.2;2.0,0.5;change_pwd;Change]"
+				"button_exit[1.1,5.2;2.5,0.5;change_pwd;Change]"
 		else
 			formspec = "size[3.4,2.0]" .. defgui .. "real_coordinates[true]" ..
 				"label[1.1,1.1;Enter Password]" ..
-				"pwdfield[1.1,1.4;2.5,0.5;pin_entry;]"
+				"pwdfield[1.1,1.4;2.5,0.5;pin_entry;]" ..
+				"button_exit[1.1,2.0;2.0,0.7;unlock_safe;Unlock " .. cn .. "]"
 		end
   else
 		-- Name of detached inventory.
@@ -720,7 +725,7 @@ function safe.on_player_receive_fields(player, formname, fields)
 	end
 
 	-- Player enters password to access the safe.
-	if fields.key_enter_field == "pin_entry" and context.locked then
+	if (fields.unlock_safe or fields.key_enter_field == "pin_entry") and context.locked then
 		local pin = (type(fields.pin_entry) == "string" and fields.pin_entry) or ""
 		local canary = safe.decrypt(pin, meta:get_string("canary"))
 

--- a/mods/teleports/functions.lua
+++ b/mods/teleports/functions.lua
@@ -683,6 +683,9 @@ teleports.update = function(pos)
 		charge = "ROSE"
 	end
 
+	local defnm = minetest.formspec_escape(name)
+	local defnt = minetest.formspec_escape(public == "true" and network or "")
+
 	local formspec = "size[11,7;]" ..
 			default.gui_bg ..
 			default.gui_bg_img ..
@@ -693,9 +696,8 @@ teleports.update = function(pos)
 			"label[1,0.70;Beacon ID: " .. minetest.formspec_escape(nm) .. "]" ..
 			"label[1,1.2;Beacon Channel: " .. minetest.formspec_escape(net) .. "]" ..
 
-			"field[0.3,2.7;2,0.5;id;Change Beacon ID;]" .. "button_exit[2,2.4;2,0.5;change_id;Confirm]" ..
-			"field[0.3,3.9;2,0.5;network;Change Channel;]" .. "button_exit[2,3.6;2,0.5;change_network;Confirm]" ..
-
+			"field[0.3,2.7;2,0.5;id;Change Beacon ID;" .. defnm .. "]" .. "field_close_on_enter[id;false]" .. "button[2,2.4;2,0.5;change_id;Confirm]" ..
+			"field[0.3,3.9;2,0.5;network;Change Channel;" .. defnt .. "]" .. "field_close_on_enter[network;false]" .. "button[2,3.6;2,0.5;change_network;Confirm]" ..
 			buttons ..
 
 			"button_exit[0,5.2;2,0.5;cancel;Close]" ..
@@ -777,7 +779,7 @@ teleports.on_receive_fields = function(pos, formname, fields, player)
 		end
 	end
 
-	if fields.change_id and fields.id then
+	if (fields.change_id or fields.key_enter_field == "id") and fields.id then
 		if owner == playername or admin then
 			meta:set_string("name", fields.id)
 			teleports.teleports[tp_idx].name = fields.id
@@ -788,7 +790,7 @@ teleports.on_receive_fields = function(pos, formname, fields, player)
 		end
 	end
 
-	if fields.change_network and fields.network then
+	if (fields.change_network or fields.key_enter_field == "network") and fields.network then
 		if owner == playername or admin then
 			meta:set_string("network", fields.network)
 			meta:mark_as_private("network")


### PR DESCRIPTION
While I'm on it, here's another quite insignificant fix to the jaunt GUI as well.

The condition on `fields.key_enter_field == "player"` here:

https://github.com/BluebirdGreycoat/musttest_game/blob/2bcf6fd048565844719b763ee5f68c9505283716/mods/jaunt/init.lua#L84

can never be true, because minetest also sets `fields.quit = true` when enter is pressed, and this:

https://github.com/BluebirdGreycoat/musttest_game/blob/2bcf6fd048565844719b763ee5f68c9505283716/mods/jaunt/init.lua#L78-L80

aborts earlier in the function.

In addition to that, I suggest to keep the formspec open when enter is pressed in the `player` field, so that if a jaunt attempt fails due to a typo in the name _(Edit: no, this *never* happens to me. Nor it happens to those trying to jaunt to me)_, one doesn't have to start over again. In case of success the formspec is already closed by the code here:

https://github.com/BluebirdGreycoat/musttest_game/blob/2bcf6fd048565844719b763ee5f68c9505283716/mods/jaunt/init.lua#L181-L182